### PR TITLE
Prevent to touch materials from another user

### DIFF
--- a/app/controllers/materials_controller.rb
+++ b/app/controllers/materials_controller.rb
@@ -1,5 +1,4 @@
 class MaterialsController < ApplicationController
-  before_action :set_material, only: %i[edit show]
   before_action :move_to_index, except: %i[index show search]
 
   def index
@@ -22,16 +21,18 @@ class MaterialsController < ApplicationController
   end
 
   def destroy
-    material = Material.find(params[:id])
+    material = current_user.materials.find(params[:id])
     material.destroy
     flash[:notice] = "投稿を削除しました"
     redirect_to("/materials")
   end
 
-  def edit; end
+  def edit
+    @material = current_user.materials.find(params[:id])
+  end
 
   def update
-    @material = Material.find(params[:id])
+    @material = current_user.materials.find(params[:id])
     length = @material.material_images.length
     i = 0
     while i < length
@@ -50,6 +51,7 @@ class MaterialsController < ApplicationController
   end
 
   def show
+    @material = Material.find(params[:id])
     @materials = Material.all
     @comment = MaterialComment.new
     @comments = @material.material_comments.includes(:user)
@@ -66,10 +68,6 @@ class MaterialsController < ApplicationController
 
   def material_params
     params.require(:material).permit(:name, :postcode, :prefecture_code, :address_city, :address_street, :address_building, :explanation, material_images_attributes: %i[src _destroy id]).merge(user_id: current_user.id)
-  end
-
-  def set_material
-    @material = Material.find(params[:id])
   end
 
   def move_to_index


### PR DESCRIPTION
セキュリティissueなのですが、習作アプリだと思うのでpublicに投稿します。

想定した仕様
---

投稿したユーザー自身にしか素材の編集・削除リンクを出していないので、他人の投稿分は変更出来ないの仕様だと思いました。

現状
---

* 編集: https://www.cooknavi.xyz/materials/2/edit の様に編集用URLへ直接アクセスすれば、他人の投稿も編集できてしまう。その際はまた、投稿者も自分に変わる
* 削除: curl を用いて DELETE method を発行すれば削除できる

という状況でした。

<img width="1232" alt="スクリーンショット 2021-02-14 22 57 10" src="https://user-images.githubusercontent.com/1180335/107879274-2f1a8780-6f1b-11eb-8e70-e1b9f5cdac57.png">
<img width="1245" alt="スクリーンショット 2021-02-14 23 01 52" src="https://user-images.githubusercontent.com/1180335/107879279-3477d200-6f1b-11eb-9d75-b83475a47d85.png">
<img width="963" alt="スクリーンショット 2021-02-14 23 13 14" src="https://user-images.githubusercontent.com/1180335/107879280-35a8ff00-6f1b-11eb-967b-6e1a1d3642f9.png">
<img width="948" alt="スクリーンショット 2021-02-14 23 13 23" src="https://user-images.githubusercontent.com/1180335/107879281-36419580-6f1b-11eb-98ee-a6fefd883e12.png">
<img width="1194" alt="スクリーンショット 2021-02-14 23 13 31" src="https://user-images.githubusercontent.com/1180335/107879282-36da2c00-6f1b-11eb-8512-66fd114f22ba.png">
<img width="359" alt="スクリーンショット 2021-02-14 23 13 48" src="https://user-images.githubusercontent.com/1180335/107879283-3772c280-6f1b-11eb-8913-57416736af35.png">

`docker-compose up` が自分の環境でうまく動かず動作確認等取れていないのですが、大体こんな感じの修正で良いのではないかなというPRを送っておきます。 🙏 